### PR TITLE
fix: rename bin to easy scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "config.js"
   ],
   "bin": {
-    "origin-scripts": "dist/index.js"
+    "easy-scripts": "dist/index.js"
   },
   "scripts": {
     "add-contributor": "node src contributors add",


### PR DESCRIPTION
Consumers of the package are unable to access the bin as it points to the old package name