### PR TITLE
fix(lintstaged): fix missed eslint lint checks on pre-commit hook

### DIFF
--- a/src/scripts/__tests__/__snapshots__/lint.js.snap
+++ b/src/scripts/__tests__/__snapshots__/lint.js.snap
@@ -4,7 +4,7 @@ exports[`lint --no-cache will disable caching 1`] = `eslint --no-cache --ext .js
 
 exports[`lint calls eslint CLI with default args 1`] = `eslint --cache --ext .js,.jsx,.ts,.tsx .`;
 
-exports[`lint runs on given files, but only js files 1`] = `eslint --cache ./src/index.js ./src/component.js --ext .js,.jsx,.ts,.tsx`;
+exports[`lint runs on given files, but only js,ts,tsx files 1`] = `eslint --cache ./src/index.js ./src/index.ts ./src/index.tsx --ext .js,.jsx,.ts,.tsx`;
 
 exports[`lint should compile files with --config and --ignore-path when using built in configs 1`] = `eslint --config ~/src/config/eslintrc.js --ignore-path ~/src/config/eslintignore --cache --ext .js,.jsx,.ts,.tsx .`;
 

--- a/src/scripts/__tests__/lint.js
+++ b/src/scripts/__tests__/lint.js
@@ -8,7 +8,7 @@ jest.mock('../../utils')
 expect.addSnapshotSerializer(unquoteSerializer)
 expect.addSnapshotSerializer(winPathSerializer)
 
-let crossSpawnSyncMock, originalArgv, printMock
+let crossSpawnSyncMock, originalArgv, printMock, originalExit
 
 cases(
   'lint',
@@ -16,7 +16,9 @@ cases(
     // beforeEach
     jest.resetModules()
     crossSpawnSyncMock = require('cross-spawn').sync
+    originalExit = process.exit
     printMock = require('../../utils').print
+    process.exit = jest.fn()
     const teardown = await setup()
     try {
       // tests
@@ -25,6 +27,7 @@ cases(
     } catch (error) {
       throw error
     } finally {
+      process.exit = originalExit
       await teardown()
     }
   },
@@ -44,13 +47,14 @@ cases(
     '--no-cache will disable caching': {
       setup: withDefault(setupWithArgs(['--no-cache'])),
     },
-    'runs on given files, but only js files': {
+    'runs on given files, but only js,ts,tsx files': {
       setup: withDefault(
         setupWithArgs([
           './src/index.js',
+          './src/index.ts',
+          './src/index.tsx',
           './package.json',
           './src/index.css',
-          './src/component.js',
         ]),
       ),
     },

--- a/src/scripts/lint.js
+++ b/src/scripts/lint.js
@@ -41,7 +41,13 @@ function lint() {
       // we need to take all the flag-less arguments (the files that should be linted)
       // and filter out the ones that aren't js files. Otherwise json or css files
       // may be passed through
-      args = args.filter(a => !parsedArgs._.includes(a) || a.endsWith('.js'))
+      args = args.filter(
+        a =>
+          !parsedArgs._.includes(a) ||
+          a.endsWith('.js') ||
+          a.endsWith('.ts') ||
+          a.endsWith('.tsx'),
+      )
     }
 
     const result = spawn.sync(
@@ -55,6 +61,9 @@ function lint() {
     } else {
       print(`Linting Successful :)`)
     }
+    // We have to process exit here for lintstaged
+    // eslint-disable-next-line no-process-exit
+    process.exit(result.status)
   } catch (error) {
     print(`Linting FAILED :(`)
     print(error)


### PR DESCRIPTION
process.exit needed to be added to the lint scripts. It was also necessary to include typescript extensions to the files given filter.